### PR TITLE
Corrigir especificação da Etapa 2

### DIFF
--- a/etapa2.md
+++ b/etapa2.md
@@ -75,7 +75,7 @@ Mensagens recebidas dentro do contexto de um grupo são exibidas de forma semelh
 
 ### Exclusão usuário de um grupo
 
-Devem ser incluidos também comandos para excluir um grupo e remover um usuário do grupo.Para remover um usuário de um determinado grupo, deve-se diponibilizar o comando "delFromGroup" seguido do <nome do usuário> e do <nome do grupo>. Exemplo:
+Devem ser incluidos também comandos para excluir um grupo e remover um usuário do grupo. Para remover um usuário de um determinado grupo, deve-se diponibilizar o comando "delFromGroup" seguido do <nome do usuário> e do <nome do grupo>. Exemplo:
 
 ```
 @marciocosta>> !delFromGroup joaosantos amigos

--- a/etapa2.md
+++ b/etapa2.md
@@ -38,7 +38,7 @@ Apesar, de nesse exemplo anterior, o usuário estar em uma seção de envio de m
 
 ### Inclusão de usuários em um grupo
 
-Para incluir um usuário em um grupo deve-se usar o comando `toGroup` seguido dos parametros nome do usuario e nome do grupo. No RabbitMQ, incluir um usuário em um grupo deve correponder a associar uma fila a um exchange usando um metodo de bind. Exemplo onde se adiciona os usuários "marciocosta" e "joaosantos" ao grupo amigos:
+Para incluir um usuário em um grupo deve-se usar o comando `addUser` seguido dos parametros nome do usuario e nome do grupo. No RabbitMQ, incluir um usuário em um grupo deve correponder a associar uma fila a um exchange usando um metodo de bind. Exemplo onde se adiciona os usuários "marciocosta" e "joaosantos" ao grupo amigos:
 
 ```
 @marciocosta>> !addUser joaosantos amigos

--- a/etapa2.md
+++ b/etapa2.md
@@ -33,7 +33,7 @@ Para criar um novo grupo, o usuario pode digitar na linha de comando do chat o s
 @marciocosta>>
 ```
 
-Apesar, de nesse exemplo anterior, o usuário estar em uma seção de envio de mensagens para "marciocosta", o chat será capaz de identificar que a entrada `!addGroup amigos` não se trata de uma mensagem a ser enviada ao usuário "marciocosta" e sim um comando ao chat, pelo fato de se iniciar com o simbolo `!`. Toda entrada iniciada com `!` deve ser tratada pelo chat como um comando. (Conforme apresentado em aula, a criacao de um grupo no chat deve ser refletir no RabbitMQ como a criacao de um exchange do tipo fanout)
+Apesar, de nesse exemplo anterior, o usuário estar em uma seção de envio de mensagens para "marciocosta", o chat será capaz de identificar que a entrada `!newGroup amigos` não se trata de uma mensagem a ser enviada ao usuário "marciocosta" e sim um comando ao chat, pelo fato de se iniciar com o simbolo `!`. Toda entrada iniciada com `!` deve ser tratada pelo chat como um comando. (Conforme apresentado em aula, a criacao de um grupo no chat deve ser refletir no RabbitMQ como a criacao de um exchange do tipo fanout)
 
 
 ### Inclusão de usuários em um grupo

--- a/etapa2.md
+++ b/etapa2.md
@@ -29,7 +29,7 @@ O chat tambem deve disponibilizar comandos de criação de grupos e de adição 
 Para criar um novo grupo, o usuario pode digitar na linha de comando do chat o simbolo `!` seguido do nome do comando `newGroup` seguido do nome do grupo que se deseja criar. Exemplo de criacao de um grupo chamado "amigos":
 
 ```
-@marciocosta>> !addGroup amigos
+@marciocosta>> !newGroup amigos
 @marciocosta>>
 ```
 


### PR DESCRIPTION
Tinham dois comandos que estavam usando 2 nomes diferentes:
- Adicionar grupo usava `newGroup` e `addGroup`
- Adicionar usuário usava `toGroup` e `addUser`

Alterei para que cada um fique com um nome só - deixei `newGroup` e `addUser` 😄 